### PR TITLE
Enable to access to GitHub private repository

### DIFF
--- a/app.go
+++ b/app.go
@@ -117,6 +117,7 @@ func (a *App) CreateRefactoringRequest(ctx context.Context, target *RefactoringT
 		}
 		pr, _, err := a.githubClient.PullRequests.Get(ctx, owner, repo, int(number))
 		if err != nil {
+			// TODO: More readable error message like `failed to retrieve the pull-request. You may not have permission to access it.`
 			return nil, fmt.Errorf("failed to get pull-request content '%s': %w", prURL, err)
 		}
 
@@ -130,6 +131,9 @@ func (a *App) CreateRefactoringRequest(ctx context.Context, target *RefactoringT
 			return nil, fmt.Errorf("failed to Do HTTP request: %w", err)
 		}
 		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("failed to get a diff of pull-request: status code from GitHub is %d: %s", resp.StatusCode, resp.Status)
+		}
 		diff, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response body: %w", err)

--- a/cmd/co-refactorer/main.go
+++ b/cmd/co-refactorer/main.go
@@ -66,8 +66,7 @@ func (c *cli) run(args []string) int {
 		return ExitError
 	}
 	httpClient := http.DefaultClient
-	githubClient := github.NewClient(nil)
-	//githubClient.WithAuthToken()
+	githubClient := createGitHubClient(nil)
 	app := corefactorer.New(c.logger, openAIClient, githubClient, httpClient)
 	c.logger.Debug("App created")
 
@@ -121,6 +120,15 @@ func createOpenAIClient() (*openai.Client, error) {
 		return nil, fmt.Errorf("env var OPENAI_API_KEY is not defined")
 	}
 	return openai.NewClient(apiKey), nil
+}
+
+func createGitHubClient(httpClient *http.Client) *github.Client {
+	c := github.NewClient(httpClient)
+	token := os.Getenv("GITHUB_TOKEN")
+	if token != "" {
+		c = c.WithAuthToken(token)
+	}
+	return c
 }
 
 func (c *cli) getPrompt(query *string, queryFile *string) (string, error) {


### PR DESCRIPTION
- closes #6 
- Users can specify with env var `GITHUB_TOKEN` to access private repositories.
